### PR TITLE
Updated code to work with Entities 0.5.1 (Unity 2019.3.0)

### DIFF
--- a/JobAnimationCurve.cs
+++ b/JobAnimationCurve.cs
@@ -9,211 +9,228 @@ using Unity.Entities;
 
 namespace E7.DataStructure
 {
-    /// <summary>
-    /// Immutable curve completely disconnected from the original <see cref="AnimationCurve"> once instantiated.
-    /// Post/pre wrap mode not supported (yet).
-    /// Curve weight not supported, until I figured out what is the underlying function.
-    /// </summary>
-    public struct JobAnimationCurve : IDisposable
+  /// <summary>
+  /// Immutable curve completely disconnected from the original <see cref="AnimationCurve"> once instantiated.
+  /// Post/pre wrap mode not supported (yet).
+  /// Curve weight not supported, until I figured out what is the underlying function.
+  /// </summary>
+  public struct JobAnimationCurve : IDisposable
+  {
+    private struct AnimationData
     {
-        private struct AnimationData
-        {
-            public BlobArray<Keyframe> keyframes;
-            //This is a hack to help stupid linear interval search, ideally we should find a better way to land on the interval without linear search in the first place.
-            public BlobArray<float> soaTimes;
-            //More hack to help the stupid linear search, cached index is for my observation that we usually evaluate on the same interval or the next one. 
-            //But ideally we have to find better way to land on the correct interval fast without this. (interval tree?)
-            public BlobArray<int> cachedIndex;
-        }
-
-        private BlobAssetReference<AnimationData> bar;
-
-        // [ReadOnly] [NativeDisableParallelForRestriction] NativeArray<Keyframe> keyframes;
-        // [ReadOnly] [NativeDisableParallelForRestriction] NativeArray<float> soaTimes;
-
-        //Not supported yet..
-        private WrapMode postWrapMode;
-        private WrapMode preWrapMode;
-        private InterpolationMode interpolationMode;
-
-        /// <summary>
-        /// Used for caching optimization. Each thread would get its own cache area which is selected based on this integer.
-        /// </summary>
-        [NativeSetThreadIndex] private int threadIndex;
-
-        public int length => bar.Value.keyframes.Length;
-
-        /// <summary>
-        /// These are currently useless, just a plan draft..
-        /// </summary>
-        public enum InterpolationMode
-        {
-            /// <summary>
-            /// This is the same thing as Unity's <see cref="AnimationCurve.Evaluate(float)">. The most accurate but also the most time consuming.
-            /// </summary>
-            CubicHermiteSpline,
-
-            /// <summary>
-            /// Not exactly like <see cref="AnimationCurve.Evaluate(float)">, each hermite basis function are approximated.
-            /// </summary>
-            ApproximatedCubicHermiteSpline,
-
-            /// <summary>
-            /// A horrible optimization that just interpolates as if a straight line is in between every nodes. It is certainly fast though!
-            /// 
-            /// You are recommended to use <see cref="IncreaseResolution(float)"> first before <see cref="Evaluate(float)"> while in this mode.
-            /// So that points that are far apart get more nodes to connect, making linear interpolation more reasonable at the cost of memory.
-            /// (If you know you have a highly curved path on far-apart pair of nodes, that will get the most error when linearly interpolated.)
-            /// </summary>
-            Linear,
-        }
-
-        /// <summary>
-        /// Replicate all keyframes of <paramref name="animationCurve"> into the struct, 
-        /// making this independent from the original reference type curve.
-        /// </summary>
-        public JobAnimationCurve(AnimationCurve animationCurve, Allocator allocator)
-        {
-            List<Keyframe> sortedKeyframes = new List<Keyframe>(animationCurve.keys);
-            if (sortedKeyframes.Any(x => x.weightedMode != WeightedMode.None))
-            {
-                throw new NotSupportedException($"Found a keyframe in the curve that has a weighted node. This is not supported until I figured out where to put the weight.");
-            }
-            sortedKeyframes.Sort(KeyframeTimeSort);
-
-            //Debug.Log(string.Join("\n", sortedKeyframes.Select(x => $"{x.time} {x.value} | {x.inTangent} {x.outTangent} | {x.inWeight} {x.outWeight} {x.weightedMode}")));
-
-            var sortedTimes = sortedKeyframes.Select(x => x.time).ToArray();
-
-            using (var ba = new BlobAllocator(-1))
-            {
-                ref var root = ref ba.ConstructRoot<AnimationData>();
-                int processorCount = SystemInfo.processorCount + 1;
-                ba.Allocate(sortedKeyframes.Count, ref root.keyframes);
-                ba.Allocate(sortedKeyframes.Count, ref root.soaTimes);
-                ba.Allocate(processorCount, ref root.cachedIndex);
-                for (int i = 0; i < sortedKeyframes.Count; i++)
-                {
-                    root.keyframes[i] = sortedKeyframes[i];
-                    root.soaTimes[i] = sortedTimes[i];
-                }
-                for (int i = 0; i < processorCount; i++)
-                {
-                    root.cachedIndex[i] = 0;
-                }
-
-                bar = ba.CreateBlobAssetReference<AnimationData>(allocator);
-            }
-
-            postWrapMode = animationCurve.postWrapMode;
-            preWrapMode = animationCurve.preWrapMode;
-            interpolationMode = InterpolationMode.CubicHermiteSpline;
-            threadIndex = 0;
-
-            int KeyframeTimeSort(Keyframe a, Keyframe b) => a.time.CompareTo(b.time);
-        }
-
-        /// <summary>
-        /// Add more points to the curve while preserving its shape.
-        /// </summary>
-        /// <param name="minimalInterval">Smallest time interval allowed in the curve. This method will add points in between if it found an interval larger than this.</param>
-        public float IncreaseResolution(float minimalInterval)
-        {
-            throw new NotImplementedException();
-        }
-
-        public float Evaluate(float time)
-        {
-            //TODO : Use interval tree to find neighbouring keyframes of a given time.
-            //for (int i = 0; i < bar.Value.soaTimes.Length; i++)
-            for (int i = bar.Value.cachedIndex[threadIndex], count = 0;
-                count < bar.Value.soaTimes.Length;
-                count++, i = (i + 1) % bar.Value.soaTimes.Length)
-            {
-                //Debug.Log($"Finding at {i} count {count}");
-                if (time >= bar.Value.soaTimes[i] && time < bar.Value.soaTimes[i + 1])
-                {
-                    //cachedIndex[threadIndex] = i;
-                    //Debug.Log($"{time} Using keyframe {i} ({soaTimes[i]}) and {i + 1} ({soaTimes[i + 1]})");
-                    // System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
-                    // sw.Start();
-                    var eval = EvaluateInternal2(
-                        time,
-                        bar.Value.keyframes[i].time,
-                        bar.Value.keyframes[i].value,
-                        bar.Value.keyframes[i].outTangent,
-                        bar.Value.keyframes[i + 1].time,
-                        bar.Value.keyframes[i + 1].value,
-                        bar.Value.keyframes[i + 1].inTangent
-                    );
-                    // sw.Stop();
-                    // Debug.Log($"TICKS {sw.ElapsedTicks}");
-                    return eval;
-                }
-                
-            }
-
-            throw new NotSupportedException($"Interval for time {time} not found! Until WrapMode is supported, you must use time that falls inside the curve's data.");
-        }
-
-        /// <summary>
-        /// This is cubic hermite spline
-        /// https://en.wikipedia.org/wiki/Cubic_Hermite_spline
-        /// 
-        /// i = interval
-        /// v = value
-        /// t = tangent
-        /// 
-        /// The function is written unexpanded for easier understanding, 
-        /// since I saw Burst is not doing any better with expanded equation (at the current version).
-        /// </summary>
-        private float EvaluateInternal(float iInterp, 
-        float iLeft, float vLeft, float tLeft, 
-        float iRight, float vRight, float tRight)
-        {
-            float t = math.unlerp(iLeft, iRight, iInterp);
-
-            //TODO: This could be precalculated from when we are creating this struct for each interval? Micro optimization?
-            float scale = iRight - iLeft;
-
-            //TODO: Maybe we could create an approximation of each hermite basis that blends into an answer?
-            float h00(float x) => (2 * x * x * x) - (3 * x * x) + 1;
-            float h10(float x) => (x * x * x) - (2 * x * x) + x;
-            float h01(float x) => -(2 * x * x * x) + (3 * x * x);
-            float h11(float x) => (x * x * x) - (x * x);
-
-            //TODO: Scaled tangents could also be precalculated. Micro optimization?
-            return (h00(t) * vLeft) + (h10(t) * scale * tLeft) + (h01(t) * vRight) + (h11(t) * scale * tRight);
-        }
-
-        /// <summary>
-        /// Matrix based version in hope that Burst could do better.
-        /// </summary>
-        private float EvaluateInternal2(float iInterp, 
-        float iLeft, float vLeft, float tLeft, 
-        float iRight, float vRight, float tRight)
-        {
-            float t = math.unlerp(iLeft, iRight, iInterp);
-            float scale = iRight - iLeft;
-
-            float4 parameters = new float4(t * t * t, t * t, t, 1);
-            float4x4 hermiteBasis = new float4x4(
-                2, -2,  1,  1,
-                -3, 3, -2, -1,
-                0,  0,  1,  0,
-                1,  0,  0,  0
-            );
-
-            //TODO : Tangent could be prescaled with also precalculated interval size.
-            float4 control = new float4(vLeft, vRight, tLeft, tRight) * new float4(1, 1, scale, scale);
-            float4 basisWithParams = math.mul(parameters, hermiteBasis);
-            float4 hermiteBlend = control * basisWithParams;
-            return math.csum(hermiteBlend);
-        }
-
-        public void Dispose()
-        {
-            bar.Release();
-        }
+      public BlobArray<Keyframe> keyframes;
+      //This is a hack to help stupid linear interval search, ideally we should find a better way to land on the interval without linear search in the first place.
+      public BlobArray<float> soaTimes;
+      //More hack to help the stupid linear search, cached index is for my observation that we usually evaluate on the same interval or the next one. 
+      //But ideally we have to find better way to land on the correct interval fast without this. (interval tree?)
+      public BlobArray<int> cachedIndex;
     }
+
+    private BlobAssetReference<AnimationData> bar;
+
+    // [ReadOnly] [NativeDisableParallelForRestriction] NativeArray<Keyframe> keyframes;
+    // [ReadOnly] [NativeDisableParallelForRestriction] NativeArray<float> soaTimes;
+
+    //Not supported yet..
+    private WrapMode postWrapMode;
+    private WrapMode preWrapMode;
+    private InterpolationMode interpolationMode;
+
+    /// <summary>
+    /// Used for caching optimization. Each thread would get its own cache area which is selected based on this integer.
+    /// </summary>
+    [NativeSetThreadIndex] private int threadIndex;
+
+    public int length => bar.Value.keyframes.Length;
+
+    /// <summary>
+    /// These are currently useless, just a plan draft..
+    /// </summary>
+    public enum InterpolationMode
+    {
+      /// <summary>
+      /// This is the same thing as Unity's <see cref="AnimationCurve.Evaluate(float)">. The most accurate but also the most time consuming.
+      /// </summary>
+      CubicHermiteSpline,
+
+      /// <summary>
+      /// Not exactly like <see cref="AnimationCurve.Evaluate(float)">, each hermite basis function are approximated.
+      /// </summary>
+      ApproximatedCubicHermiteSpline,
+
+      /// <summary>
+      /// A horrible optimization that just interpolates as if a straight line is in between every nodes. It is certainly fast though!
+      /// 
+      /// You are recommended to use <see cref="IncreaseResolution(float)"> first before <see cref="Evaluate(float)"> while in this mode.
+      /// So that points that are far apart get more nodes to connect, making linear interpolation more reasonable at the cost of memory.
+      /// (If you know you have a highly curved path on far-apart pair of nodes, that will get the most error when linearly interpolated.)
+      /// </summary>
+      Linear,
+    }
+
+    /// <summary>
+    /// Replicate all keyframes of <paramref name="animationCurve"> into the struct, 
+    /// making this independent from the original reference type curve.
+    /// </summary>
+    public JobAnimationCurve(AnimationCurve animationCurve, Allocator allocator)
+    {
+      List<Keyframe> sortedKeyframes = new List<Keyframe>(animationCurve.keys);
+      if (sortedKeyframes.Any(x => x.weightedMode != WeightedMode.None))
+      {
+        throw new NotSupportedException($"Found a keyframe in the curve that has a weighted node. This is not supported until I figured out where to put the weight.");
+      }
+      sortedKeyframes.Sort(KeyframeTimeSort);
+
+      //Debug.Log(string.Join("\n", sortedKeyframes.Select(x => $"{x.time} {x.value} | {x.inTangent} {x.outTangent} | {x.inWeight} {x.outWeight} {x.weightedMode}")));
+
+      var sortedTimes = sortedKeyframes.Select(x => x.time).ToArray();
+
+      // The following (redundant) leading comments are the steps from BlobBuilder's
+      // documentation https://docs.unity3d.com/Packages/com.unity.entities@0.5/api/Unity.Entities.BlobBuilder.html
+      // Create a BlobBuilder object
+      using (var builder = new BlobBuilder(allocator))
+      {
+        // Call the ConstructRoot<T>() method, where T is the struct definng the asset structure.
+        // (Declare the structure of the blob asset as a struct.)
+        ref var root = ref builder.ConstructRoot<AnimationData>();
+
+        // Initialize primitive values defined at the root level of the asset.
+        // Allocate memory for arrays, structs, and BlobString instances at the root.
+
+        // Used to use the processor count to assume the max thread count, which is a fallacy
+        // int processorCount = SystemInfo.processorCount + 1;
+        int maxThreadCount = Unity.Jobs.LowLevel.Unsafe.JobsUtility.MaxJobThreadCount;
+        var keyframes = builder.Allocate(ref root.keyframes, sortedKeyframes.Count);
+        var soaTimes = builder.Allocate(ref root.soaTimes, sortedKeyframes.Count);
+        var cachedIndex = builder.Allocate(ref root.cachedIndex, maxThreadCount);
+
+        // Initialize the values of those arrays, structs, and strings.
+        for (int i = 0; i < sortedKeyframes.Count; i++)
+        {
+          keyframes[i] = sortedKeyframes[i];
+          soaTimes[i] = sortedTimes[i];
+        }
+        for (int i = 0; i < maxThreadCount; i++)
+        {
+          cachedIndex[i] = 0;
+        }
+        // Continue allocating memory and initializing values until you have fully constructed the asset.
+
+        // Call CreateBlobAssetReference<T>(Allocator) to create a reference to the blob asset in memory.
+        bar = builder.CreateBlobAssetReference<AnimationData>(allocator);
+
+        // Dispose the BlobBuilder object.
+      }
+
+      postWrapMode = animationCurve.postWrapMode;
+      preWrapMode = animationCurve.preWrapMode;
+      interpolationMode = InterpolationMode.CubicHermiteSpline;
+      threadIndex = 0;
+
+      int KeyframeTimeSort(Keyframe a, Keyframe b) => a.time.CompareTo(b.time);
+    }
+
+    /// <summary>
+    /// Add more points to the curve while preserving its shape.
+    /// </summary>
+    /// <param name="minimalInterval">Smallest time interval allowed in the curve. This method will add points in between if it found an interval larger than this.</param>
+    public float IncreaseResolution(float minimalInterval)
+    {
+      throw new NotImplementedException();
+    }
+
+    public float Evaluate(float time)
+    {
+      //TODO : Use interval tree to find neighbouring keyframes of a given time.
+      //for (int i = 0; i < bar.Value.soaTimes.Length; i++)
+      for (int i = bar.Value.cachedIndex[threadIndex], count = 0;
+          count < bar.Value.soaTimes.Length;
+          count++, i = (i + 1) % bar.Value.soaTimes.Length)
+      {
+        //Debug.Log($"Finding at {i} count {count}");
+        if (time >= bar.Value.soaTimes[i] && time < bar.Value.soaTimes[i + 1])
+        {
+          //cachedIndex[threadIndex] = i;
+          //Debug.Log($"{time} Using keyframe {i} ({soaTimes[i]}) and {i + 1} ({soaTimes[i + 1]})");
+          // System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
+          // sw.Start();
+          var eval = EvaluateInternal2(
+              time,
+              bar.Value.keyframes[i].time,
+              bar.Value.keyframes[i].value,
+              bar.Value.keyframes[i].outTangent,
+              bar.Value.keyframes[i + 1].time,
+              bar.Value.keyframes[i + 1].value,
+              bar.Value.keyframes[i + 1].inTangent
+          );
+          // sw.Stop();
+          // Debug.Log($"TICKS {sw.ElapsedTicks}");
+          return eval;
+        }
+
+      }
+
+      throw new NotSupportedException($"Interval for time {time} not found! Until WrapMode is supported, you must use time that falls inside the curve's data.");
+    }
+
+    /// <summary>
+    /// This is cubic hermite spline
+    /// https://en.wikipedia.org/wiki/Cubic_Hermite_spline
+    /// 
+    /// i = interval
+    /// v = value
+    /// t = tangent
+    /// 
+    /// The function is written unexpanded for easier understanding, 
+    /// since I saw Burst is not doing any better with expanded equation (at the current version).
+    /// </summary>
+    private float EvaluateInternal(float iInterp,
+    float iLeft, float vLeft, float tLeft,
+    float iRight, float vRight, float tRight)
+    {
+      float t = math.unlerp(iLeft, iRight, iInterp);
+
+      //TODO: This could be precalculated from when we are creating this struct for each interval? Micro optimization?
+      float scale = iRight - iLeft;
+
+      //TODO: Maybe we could create an approximation of each hermite basis that blends into an answer?
+      float h00(float x) => (2 * x * x * x) - (3 * x * x) + 1;
+      float h10(float x) => (x * x * x) - (2 * x * x) + x;
+      float h01(float x) => -(2 * x * x * x) + (3 * x * x);
+      float h11(float x) => (x * x * x) - (x * x);
+
+      //TODO: Scaled tangents could also be precalculated. Micro optimization?
+      return (h00(t) * vLeft) + (h10(t) * scale * tLeft) + (h01(t) * vRight) + (h11(t) * scale * tRight);
+    }
+
+    /// <summary>
+    /// Matrix based version in hope that Burst could do better.
+    /// </summary>
+    private float EvaluateInternal2(float iInterp,
+    float iLeft, float vLeft, float tLeft,
+    float iRight, float vRight, float tRight)
+    {
+      float t = math.unlerp(iLeft, iRight, iInterp);
+      float scale = iRight - iLeft;
+
+      float4 parameters = new float4(t * t * t, t * t, t, 1);
+      float4x4 hermiteBasis = new float4x4(
+          2, -2, 1, 1,
+          -3, 3, -2, -1,
+          0, 0, 1, 0,
+          1, 0, 0, 0
+      );
+
+      //TODO : Tangent could be prescaled with also precalculated interval size.
+      float4 control = new float4(vLeft, vRight, tLeft, tRight) * new float4(1, 1, scale, scale);
+      float4 basisWithParams = math.mul(parameters, hermiteBasis);
+      float4 hermiteBlend = control * basisWithParams;
+      return math.csum(hermiteBlend);
+    }
+
+    public void Dispose()
+    {
+      bar.Dispose();
+    }
+  }
 }

--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4366368db59304387b6e672b46766b53
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # JobAnimationCurve
 
-Currently the performance sucks but it did give equal answer (without weight) to `AnimationCurve` and works in a job.
+Currently the performance sucks (from 4 to _2500_ times slower!!) but it did give equal answer (without weight) to `AnimationCurve` and works in a job.

--- a/Tests/JobAnimationCurveTests.cs
+++ b/Tests/JobAnimationCurveTests.cs
@@ -10,228 +10,235 @@ using UnityEngine;
 
 namespace Tests
 {
-    public class JobAnimationCurveTests
+  public class JobAnimationCurveTests
+  {
+    private const int testEvaluateBatchCount = 10;
+
+    private AnimationCurve RandomCurve(int resolution)
     {
-        private const int testEvaluateBatchCount = 10;
-
-        private AnimationCurve RandomCurve(int resolution)
-        {
-            Random.InitState(1234567);
-            var kf = new List<Keyframe>();
-            for (int i = 0; i < resolution; i++)
-            {
-                kf.Add(new Keyframe(math.unlerp(0, resolution - 1, i), Random.value, math.tan(math.radians(Random.value * 360)), math.tan(math.radians(Random.value * 360))));
-            }
-            return new AnimationCurve(kf.ToArray());
-        }
-
-        [BurstCompile]
-        private struct CurveEvaluationJob : IJobParallelFor
-        {
-            [NativeDisableParallelForRestriction] public NativeArray<float> evaluated;
-            public JobAnimationCurve jobAnimationCurve;
-
-            public void Execute(int index)
-            {
-                evaluated[index] = jobAnimationCurve.Evaluate(index / (float)evaluated.Length);
-            }
-        }
-
-        [Test]
-        public void Instantiation()
-        {
-            using (var jac = new JobAnimationCurve(RandomCurve(10), Allocator.TempJob)) { }
-        }
-
-        [Test]
-        public void Evaluate2EaseInOut([Values(10, 100, 1000)] int evaluationResolution)
-        {
-            TestEvaluate(AnimationCurve.EaseInOut(0, 0, 1, 1), evaluationResolution);
-        }
-
-        [Test]
-        [Ignore("This works if I remove a weight check in the code, since this setup weighted into the same curve.")]
-        public void Evaluate2WeightedUnweight([Values(10, 100, 1000)] int evaluationResolution)
-        {
-            var ac = AnimationCurve.EaseInOut(0, 0, 1, 1);
-            var keys = ac.keys;
-            keys[0].outWeight = 0.3333333333f;
-            keys[0].weightedMode = WeightedMode.Both;
-            keys[1].inWeight = 0.3333333333f;
-            keys[1].weightedMode = WeightedMode.Both;
-            ac.keys = keys;
-            TestEvaluate(ac, evaluationResolution);
-        }
-
-        [Test]
-        [Ignore("This works if I remove a weight check in the code, since this setup weighted into the same curve.")]
-        public void Evaluate2WeightedUnweightLinear([Values(10, 100, 1000)] int evaluationResolution)
-        {
-            //If the tangents are both 1, weight has no effect.
-
-            var ac = AnimationCurve.EaseInOut(0, 0, 1, 1);
-            var keys = ac.keys;
-            keys[0].outTangent = 1;
-            keys[0].outWeight = 0.15f;
-            keys[0].weightedMode = WeightedMode.Both;
-            keys[1].inTangent = 1;
-            keys[1].inWeight = 0.7f;
-            keys[1].weightedMode = WeightedMode.Both;
-            ac.keys = keys;
-            TestEvaluate(ac, evaluationResolution);
-        }
-
-        [Test]
-        [Ignore("Because weight doesn't work yet...")]
-        public void Evaluate2Weighted([Values(10, 100, 1000)] int evaluationResolution)
-        {
-            var ac = AnimationCurve.EaseInOut(0, 0, 1, 1);
-            var keys = ac.keys;
-            keys[0].outWeight = 0.15f;
-            keys[0].weightedMode = WeightedMode.Both;
-            keys[1].inWeight = 0.7f;
-            keys[1].weightedMode = WeightedMode.Both;
-            ac.keys = keys;
-            TestEvaluate(ac, evaluationResolution);
-        }
-
-
-        [Test]
-        public void Evaluate2Tangents([Values(10, 100, 1000)] int evaluationResolution)
-        {
-            var ac = AnimationCurve.EaseInOut(0, 0, 1, 1);
-            var keys = ac.keys;
-            keys[0].outTangent = math.tan(math.radians(55));
-            keys[1].inTangent = math.tan(math.radians(12));
-            ac.keys = keys;
-
-            TestEvaluate(ac, evaluationResolution);
-        }
-
-        [Test]
-        public void Evaluate2TangentsAndValues([Values(10, 100, 1000)] int evaluationResolution)
-        {
-            var ac = AnimationCurve.EaseInOut(0, 0, 1, 1);
-            var keys = ac.keys;
-            keys[0].outTangent = math.tan(math.radians(55));
-            keys[0].value = 213.412f;
-            keys[1].inTangent = math.tan(math.radians(12));
-            keys[1].value = 152.3244f;
-            ac.keys = keys;
-
-            TestEvaluate(ac, evaluationResolution);
-        }
-
-        [Test]
-        public void Evaluate2TangentsAndValuesWithUnrelatedTangents ([Values(10, 100, 1000)] int evaluationResolution)
-        {
-            var ac = AnimationCurve.EaseInOut(0, 0, 1, 1);
-            var keys = ac.keys;
-            keys[0].outTangent = math.tan(math.radians(55));
-            keys[0].value = 213.412f;
-            keys[1].inTangent = math.tan(math.radians(12));
-            keys[1].value = 152.3244f;
-
-            keys[0].inTangent = math.tan(math.radians(44));
-            keys[0].outTangent = math.tan(math.radians(33));
-
-            ac.keys = keys;
-
-            TestEvaluate(ac, evaluationResolution);
-        }
-
-        [Test]
-        public void EvaluateRandomCurves([Values(/* 1,*/ 2, 3, 10, 100, 1000)] int curveResolution, [Values(10, 100, 1000)] int evaluationResolution)
-        {
-            TestEvaluate(RandomCurve(curveResolution), evaluationResolution);
-        }
-
-        [Test]
-        public void EvaluateRandomCurvesOnNode([Values(1, 10, 100, 1000)]int nodes)
-        {
-            TestEvaluate(RandomCurve(nodes + 1), nodes);
-        }
-
-        [Test]
-        [Description("On purely main thread, the replicate algorithm should be competitive to Unity ones.")]
-        public void MainThreadPerformanceTest([Values(/* 1,*/ 2, 3, 10, 100, 1000)] int curveResolution, [Values(10, 100, 1000)] int evaluationResolution)
-        {
-            var ticks = MainThreadPerformanceTest(RandomCurve(curveResolution), evaluationResolution);
-            Assert.That(ticks.jobTicks, Is.LessThan(ticks.mainTicks));
-        }
-
-        private (long mainTicks, long jobTicks) MainThreadPerformanceTest(AnimationCurve ac, int iterationCount)
-        {
-            System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
-
-            var jac = new JobAnimationCurve(ac, Allocator.Temp);
-
-            float[] evaluated = new float[iterationCount];
-
-            sw.Start();
-            for (int i = 0; i < evaluated.Length; i++)
-            {
-                evaluated[i] = jac.Evaluate(i / (float)iterationCount);
-            }
-            sw.Stop();
-            var jobTicks = sw.ElapsedTicks;
-
-            sw.Reset();
-
-            sw.Start();
-            for (int i = 0; i < evaluated.Length; i++)
-            {
-                evaluated[i] = ac.Evaluate(i / (float)iterationCount);
-            }
-            sw.Stop();
-            var mainTicks = sw.ElapsedTicks;
-
-
-            jac.Dispose();
-
-            return (mainTicks, jobTicks);
-        }
-
-        private (long mainTicks, long jobTicks) TestEvaluate(AnimationCurve ac, int iterationCount)
-        {
-            System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
-
-            var jac = new JobAnimationCurve(ac, Allocator.TempJob);
-
-            NativeArray<float> evaluated = new NativeArray<float>(iterationCount, Allocator.TempJob);
-            NativeArray<float> jobEvaluated = new NativeArray<float>(iterationCount, Allocator.TempJob);
-            var job = new CurveEvaluationJob
-            {
-                evaluated = jobEvaluated,
-                jobAnimationCurve = jac
-            }.Schedule(iterationCount, testEvaluateBatchCount, default(JobHandle));
-
-            sw.Start();
-            for (int i = 0; i < evaluated.Length; i++)
-            {
-                evaluated[i] = ac.Evaluate(i / (float)iterationCount);
-            }
-            sw.Stop();
-            var mainTicks = sw.ElapsedTicks;
-            sw.Reset();
-
-            sw.Start();
-            job.Complete();
-            sw.Stop();
-            var jobTicks = sw.ElapsedTicks;
-
-            for (int i = 0; i < evaluated.Length; i++)
-            {
-                //Within 0.00001f, it is a bit inaccurate.
-                Assert.That(evaluated[i], Is.EqualTo(jobEvaluated[i]).Within(0.0001f),
-                $"At index {i} (time {i / (float)iterationCount}) there is a difference of Unity {evaluated[i]} and Job {jobEvaluated[i]} ({evaluated[i] - jobEvaluated[i]})");
-            }
-
-            evaluated.Dispose();
-            jobEvaluated.Dispose();
-            jac.Dispose();
-
-            return (mainTicks, jobTicks);
-        }
+      Random.InitState(1234567);
+      var kf = new List<Keyframe>();
+      for (int i = 0; i < resolution; i++)
+      {
+        kf.Add(new Keyframe(math.unlerp(0, resolution - 1, i), Random.value, math.tan(math.radians(Random.value * 360)), math.tan(math.radians(Random.value * 360))));
+      }
+      return new AnimationCurve(kf.ToArray());
     }
+
+    [BurstCompile]
+    private struct CurveEvaluationJob : IJobParallelFor
+    {
+      [NativeDisableParallelForRestriction] public NativeArray<float> evaluated;
+      public JobAnimationCurve jobAnimationCurve;
+
+      public void Execute(int index)
+      {
+        evaluated[index] = jobAnimationCurve.Evaluate(index / (float)evaluated.Length);
+      }
+    }
+
+    [Test]
+    public void Instantiation()
+    {
+      using (var jac = new JobAnimationCurve(RandomCurve(10), Allocator.TempJob)) { }
+    }
+
+    [Test]
+    public void Evaluate2EaseInOut([Values(10, 100, 1000)] int evaluationResolution)
+    {
+      TestEvaluate(AnimationCurve.EaseInOut(0, 0, 1, 1), evaluationResolution);
+    }
+
+    [Test]
+    [Ignore("This works if I remove a weight check in the code, since this setup weighted into the same curve.")]
+    public void Evaluate2WeightedUnweight([Values(10, 100, 1000)] int evaluationResolution)
+    {
+      var ac = AnimationCurve.EaseInOut(0, 0, 1, 1);
+      var keys = ac.keys;
+      keys[0].outWeight = 0.3333333333f;
+      keys[0].weightedMode = WeightedMode.Both;
+      keys[1].inWeight = 0.3333333333f;
+      keys[1].weightedMode = WeightedMode.Both;
+      ac.keys = keys;
+      TestEvaluate(ac, evaluationResolution);
+    }
+
+    [Test]
+    [Ignore("This works if I remove a weight check in the code, since this setup weighted into the same curve.")]
+    public void Evaluate2WeightedUnweightLinear([Values(10, 100, 1000)] int evaluationResolution)
+    {
+      //If the tangents are both 1, weight has no effect.
+
+      var ac = AnimationCurve.EaseInOut(0, 0, 1, 1);
+      var keys = ac.keys;
+      keys[0].outTangent = 1;
+      keys[0].outWeight = 0.15f;
+      keys[0].weightedMode = WeightedMode.Both;
+      keys[1].inTangent = 1;
+      keys[1].inWeight = 0.7f;
+      keys[1].weightedMode = WeightedMode.Both;
+      ac.keys = keys;
+      TestEvaluate(ac, evaluationResolution);
+    }
+
+    [Test]
+    [Ignore("Because weight doesn't work yet...")]
+    public void Evaluate2Weighted([Values(10, 100, 1000)] int evaluationResolution)
+    {
+      var ac = AnimationCurve.EaseInOut(0, 0, 1, 1);
+      var keys = ac.keys;
+      keys[0].outWeight = 0.15f;
+      keys[0].weightedMode = WeightedMode.Both;
+      keys[1].inWeight = 0.7f;
+      keys[1].weightedMode = WeightedMode.Both;
+      ac.keys = keys;
+      TestEvaluate(ac, evaluationResolution);
+    }
+
+
+    [Test]
+    public void Evaluate2Tangents([Values(10, 100, 1000)] int evaluationResolution)
+    {
+      var ac = AnimationCurve.EaseInOut(0, 0, 1, 1);
+      var keys = ac.keys;
+      keys[0].outTangent = math.tan(math.radians(55));
+      keys[1].inTangent = math.tan(math.radians(12));
+      ac.keys = keys;
+
+      TestEvaluate(ac, evaluationResolution);
+    }
+
+    [Test]
+    public void Evaluate2TangentsAndValues([Values(10, 100, 1000)] int evaluationResolution)
+    {
+      var ac = AnimationCurve.EaseInOut(0, 0, 1, 1);
+      var keys = ac.keys;
+      keys[0].outTangent = math.tan(math.radians(55));
+      keys[0].value = 213.412f;
+      keys[1].inTangent = math.tan(math.radians(12));
+      keys[1].value = 152.3244f;
+      ac.keys = keys;
+
+      TestEvaluate(ac, evaluationResolution);
+    }
+
+    [Test]
+    public void Evaluate2TangentsAndValuesWithUnrelatedTangents([Values(10, 100, 1000)] int evaluationResolution)
+    {
+      var ac = AnimationCurve.EaseInOut(0, 0, 1, 1);
+      var keys = ac.keys;
+      keys[0].outTangent = math.tan(math.radians(55));
+      keys[0].value = 213.412f;
+      keys[1].inTangent = math.tan(math.radians(12));
+      keys[1].value = 152.3244f;
+
+      keys[0].inTangent = math.tan(math.radians(44));
+      keys[0].outTangent = math.tan(math.radians(33));
+
+      ac.keys = keys;
+
+      TestEvaluate(ac, evaluationResolution);
+    }
+
+    [Test]
+    public void EvaluateRandomCurves([Values(/* 1,*/ 2, 3, 10, 100, 1000)] int curveResolution, [Values(10, 100, 1000)] int evaluationResolution)
+    {
+      TestEvaluate(RandomCurve(curveResolution), evaluationResolution);
+    }
+
+    [Test]
+    public void EvaluateRandomCurvesOnNode([Values(1, 10, 100, 1000)]int nodes)
+    {
+      TestEvaluate(RandomCurve(nodes + 1), nodes);
+    }
+
+    // Output values are in ticks.  There are System.Diagnostics.Stopwatch.Frequency ticks in a second
+    [Test]
+    [Description("On purely main thread, the replicate algorithm should be competitive to Unity ones.")]
+    public void MainThreadPerformanceTest([Values(/* 1,*/ 2, 3, 10, 100, 1000)] int curveResolution, [Values(10, 100, 1000)] int evaluationResolution)
+    {
+      var ticks = MainThreadPerformanceTest(RandomCurve(curveResolution), evaluationResolution);
+
+      // Ticks per second
+      double frequency = System.Diagnostics.Stopwatch.Frequency;
+      double jobTime = (ticks.jobTicks / frequency) * 1e3;
+      double mainTime = (ticks.mainTicks / frequency) * 1e3;
+
+      Assert.That(ticks.jobTicks, Is.LessThan(ticks.mainTicks), "Main time: " + mainTime + "ms.  Job time: " + jobTime + "ms\nFollowing values are in ticks:\n");
+    }
+
+    private (long mainTicks, long jobTicks) MainThreadPerformanceTest(AnimationCurve ac, int iterationCount)
+    {
+      System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
+
+      var jac = new JobAnimationCurve(ac, Allocator.Temp);
+
+      float[] evaluated = new float[iterationCount];
+
+      sw.Start();
+      for (int i = 0; i < evaluated.Length; i++)
+      {
+        evaluated[i] = jac.Evaluate(i / (float)iterationCount);
+      }
+      sw.Stop();
+      var jobTicks = sw.ElapsedTicks;
+
+      sw.Reset();
+
+      sw.Start();
+      for (int i = 0; i < evaluated.Length; i++)
+      {
+        evaluated[i] = ac.Evaluate(i / (float)iterationCount);
+      }
+      sw.Stop();
+      var mainTicks = sw.ElapsedTicks;
+
+
+      jac.Dispose();
+
+      return (mainTicks, jobTicks);
+    }
+
+    private (long mainTicks, long jobTicks) TestEvaluate(AnimationCurve ac, int iterationCount)
+    {
+      System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
+
+      var jac = new JobAnimationCurve(ac, Allocator.TempJob);
+
+      NativeArray<float> evaluated = new NativeArray<float>(iterationCount, Allocator.TempJob);
+      NativeArray<float> jobEvaluated = new NativeArray<float>(iterationCount, Allocator.TempJob);
+      var job = new CurveEvaluationJob
+      {
+        evaluated = jobEvaluated,
+        jobAnimationCurve = jac
+      }.Schedule(iterationCount, testEvaluateBatchCount, default(JobHandle));
+
+      sw.Start();
+      for (int i = 0; i < evaluated.Length; i++)
+      {
+        evaluated[i] = ac.Evaluate(i / (float)iterationCount);
+      }
+      sw.Stop();
+      var mainTicks = sw.ElapsedTicks;
+      sw.Reset();
+
+      sw.Start();
+      job.Complete();
+      sw.Stop();
+      var jobTicks = sw.ElapsedTicks;
+
+      for (int i = 0; i < evaluated.Length; i++)
+      {
+        //Within 0.00001f, it is a bit inaccurate.
+        Assert.That(evaluated[i], Is.EqualTo(jobEvaluated[i]).Within(0.0001f),
+        $"At index {i} (time {i / (float)iterationCount}) there is a difference of Unity {evaluated[i]} and Job {jobEvaluated[i]} ({evaluated[i] - jobEvaluated[i]})");
+      }
+
+      evaluated.Dispose();
+      jobEvaluated.Dispose();
+      jac.Dispose();
+
+      return (mainTicks, jobTicks);
+    }
+  }
 }


### PR DESCRIPTION
Removed the usage of BlobAllocator and replaced it with BlobBuilder.  Fixed a out-of-range error due to thread index being greater than processor count during job.  Added a small message to the performance test outputs that presents the time in milliseconds.

The changes shown in the difference compare are much less in reality.  I think the line endings were switched, and then git thinks all those lines are changed.  The edits done are described in my brief summary above.